### PR TITLE
Changed apt-mirror provider to dynamically generate temp config file.

### DIFF
--- a/providers.d/apt-mirror/provider_wrapper.sh
+++ b/providers.d/apt-mirror/provider_wrapper.sh
@@ -1,7 +1,12 @@
 bashelliteProviderWrapper() {
 
+  local temp_config_file="/tmp/bashellite_tmp_${_n_repo_name}_config.conf"
+  local provider_config_file="${_r_metadata_tld}/repos.conf.d/${_n_repo_name}/provider.conf"
+
   if [[ ! ${_r_dryrun} ]]; then
-    apt-mirror ${_r_metadata_tld}/repos.conf.d/${_n_repo_name}/provider.conf;
+    echo "set base_path         ${_r_mirror_tld}/${_n_mirror_repo_name}" > ${temp_config_file};
+    cat ${provider_config_file} >> ${temp_config_file};
+    apt-mirror ${temp_config_file};
   fi
 
   if [[ "${?}" != "0" ]]; then

--- a/providers.d/apt-mirror/provider_wrapper.sh
+++ b/providers.d/apt-mirror/provider_wrapper.sh
@@ -1,6 +1,6 @@
 bashelliteProviderWrapper() {
 
-  local temp_config_file="/tmp/bashellite_tmp_${_n_repo_name}_config.conf"
+  local temp_config_file="${HOME}/.bashellite/bashellite_tmp_${_n_repo_name}_config.conf"
   local provider_config_file="${_r_metadata_tld}/repos.conf.d/${_n_repo_name}/provider.conf"
 
   if [[ ! ${_r_dryrun} ]]; then


### PR DESCRIPTION
Previously the provider.conf file had a hardcoded value for the base
folder to download to.  This would ignore any value that was in the
bashellite.conf file or the value passed with the -m option.

This behavior has been corrected to write to a temp file in the /tmp
folder where the "set base_path" is dynically taken from the mirror_tld
and mirror_repo_name passed in variables.