### PR TITLE
Patch/fix rubygems mirror provider

### DIFF
--- a/providers.d/gem/install_provider.sh
+++ b/providers.d/gem/install_provider.sh
@@ -22,12 +22,15 @@ main() {
   else
     echo "[WARN] ${bin_name} does NOT appear to be installed, (or it is broken); (re)installing..."
     # Download ruby-install
-    git clone https://github.com/pcseanmckay/ruby-install ${providers_tld}/gem/src/ruby-install
+    if [ ! -d ${providers_tld/gem/src/ruby-install} ]; then
+      git clone https://github.com/pcseanmckay/ruby-install ${providers_tld}/gem/src/ruby-install
+    fi
     
     # Install ruby to /home/bashellite/.rubies
     local ruby_installer="${providers_tld}/gem/src/ruby-install/bin/ruby-install"
     local ruby_src_dir="${providers_tld}/gem/src/ruby_src"
     local ruby_install_dir="/home/bashellite/.rubies/ruby-2.5.1"
+    
     ${ruby_installer} -i ${ruby_install_dir} -s ${ruby_src_dir} ruby 2.5.1
     chown -R bashellite:bashellite /home/bashellite/.rubies
     chmod -R 0700 /home/bashellite/.rubies

--- a/providers.d/gem/install_provider.sh
+++ b/providers.d/gem/install_provider.sh
@@ -30,11 +30,12 @@ main() {
     # Install ruby to /home/bashellite/.rubies
     local ruby_installer="${providers_tld}/gem/src/ruby-install/bin/ruby-install"
     local ruby_src_dir="${providers_tld}/gem/src/ruby_src"
-    local ruby_install_dir="/home/bashellite/.rubies/ruby-${ruby_ver}"
+    local ruby_install_dir="/home/bashellite/.rubies"
+    local ruby_dir="${ruby_install_dir}/ruby-${ruby_ver}"
     
-    ${ruby_installer} -i ${ruby_install_dir} -s ${ruby_src_dir} ruby ${ruby_ver}
-    chown -R bashellite:bashellite /home/bashellite/.rubies
-    chmod -R 0700 /home/bashellite/.rubies
+    ${ruby_installer} -i ${ruby_dir} -s ${ruby_src_dir} ruby ${ruby_ver}
+    chown -R bashellite:bashellite ${ruby_install_dir}
+    chmod -R 0700 ${ruby_install_dir}
 
     # Check installation of ruby
     if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby ${ruby_ver}") == "ruby ${ruby_ver}" ]]; then

--- a/providers.d/gem/install_provider.sh
+++ b/providers.d/gem/install_provider.sh
@@ -2,11 +2,11 @@
 
 main() {
 
-  local bin_name="gem";
+  local bin_name="ruby";
 
   for dep in \
-             ruby \
-             ${bin_name} \
+             git \
+             make \
              ; do
     which ${dep} &>/dev/null \
     || {
@@ -15,56 +15,32 @@ main() {
        };
   done;
 
-  local gemlist
+  # Check to see if ruby is already installed in /home/bashellite/.rubies, if not install it.
+  local ruby_bin="/home/bashellite/.rubies/ruby-2.5.1/bin/ruby"
+  if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby 2.5.1") == "ruby 2.5.1" ]]; then
+    echo "[INFO] ${bin_name} provider successfully installed.";
+  else
+    echo "[WARN] ${bin_name} does NOT appear to be installed, (or it is broken); (re)installing..."
+    # Download ruby-install
+    git clone https://github.com/pcseanmckay/ruby-install ${providers_tld}/gem/src/ruby-install
+    
+    # Install ruby to /home/bashellite/.rubies
+    local ruby_installer="${providers_tld}/gem/src/ruby-install/bin/ruby-install"
+    local ruby_src_dir="${providers_tld}/gem/src/ruby_src"
+    local ruby_install_dir="/home/bashellite/.rubies/ruby-2.5.1"
+    ${ruby_installer} -i ${ruby_install_dir} -s ${ruby_src_dir} ruby 2.5.1
+    chown -R bashellite:bashellite /home/bashellite/.rubies
+    chmod -R 0700 /home/bashellite/.rubies
 
-  for gem in \
-      bundler \
-      rake \
-      hoe \
-      ; do
-    gemlist=$(gem list)
-    if [[ "${gemlist}" != *"${gem}"* ]]; then 
-      echo "[WARN] ${gem} gem dependency not found.  Installing..."
-      gem install ${gem}
-      gemlist=$(gem list)
-      if [[ "${gemlist}" == *"${gem}"* ]]; then
-        echo "[INFO] ${gem} installed successfully..."
-      else
-        echo "[FAIL] ${gem} was NOT installed successfully; exiting." \
-        && exit 1;
-      fi
-    fi 
-  done
-
-  gemlist=$(gem list)
-  local gem="net-http-persistent"
-  if [[ "${gemlist}" != *"${gem}"* ]]; then 
-    echo "[WARN] ${gem} gem dependency not found.  Installing..."
-    gem install -i /usr/share/gems ${gem} -v 2.9.4
-    gemlist=$(gem list)
-    if [[ "${gemlist}" == *"${gem}"* ]]; then
-      echo "[INFO] ${gem} installed successfully..."
+    # Check installation of ruby
+    if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby 2.5.1") == "ruby 2.5.1" ]]; then
+      echo "[INFO] ${bin_name} provider successfully installed.";
     else
-      echo "[FAIL] ${gem} was NOT installed successfully; exiting." \
+      echo "[FAIL] ${bin_name} was NOT installed successfully; exiting." \
       && exit 1;
     fi
   fi
 
-  gemlist=$(ls ${providers_tld}/gem/exec/gems)
-  gem="rubygems-mirror"
-  if [[ "${gemlist}" != *"${gem}"* ]]; then 
-    echo "[WARN] ${gem} gem dependency not found.  Installing..."
-    gem install -i ${providers_tld}/gem/exec ${gem}
-    gemlist=$(ls ${providers_tld}/gem/exec/gems)
-    if [[ "${gemlist}" == *"${gem}"* ]]; then
-      echo "[INFO] ${gem} installed successfully..."
-    else
-      echo "[FAIL] ${gem} was NOT installed successfully; exiting." \
-      && exit 1;
-    fi
-  fi
-
-  echo "[INFO] ${bin_name} provider successfully installed.";
 }
 
 main

--- a/providers.d/gem/install_provider.sh
+++ b/providers.d/gem/install_provider.sh
@@ -3,6 +3,7 @@
 main() {
 
   local bin_name="ruby";
+  local ruby_ver="2.5.1";
 
   for dep in \
              git \
@@ -16,8 +17,8 @@ main() {
   done;
 
   # Check to see if ruby is already installed in /home/bashellite/.rubies, if not install it.
-  local ruby_bin="/home/bashellite/.rubies/ruby-2.5.1/bin/ruby"
-  if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby 2.5.1") == "ruby 2.5.1" ]]; then
+  local ruby_bin="/home/bashellite/.rubies/ruby-${ruby_ver}/bin/ruby"
+  if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby ${ruby_ver}") == "ruby ${ruby_ver}" ]]; then
     echo "[INFO] ${bin_name} provider successfully installed.";
   else
     echo "[WARN] ${bin_name} does NOT appear to be installed, (or it is broken); (re)installing..."
@@ -29,14 +30,14 @@ main() {
     # Install ruby to /home/bashellite/.rubies
     local ruby_installer="${providers_tld}/gem/src/ruby-install/bin/ruby-install"
     local ruby_src_dir="${providers_tld}/gem/src/ruby_src"
-    local ruby_install_dir="/home/bashellite/.rubies/ruby-2.5.1"
+    local ruby_install_dir="/home/bashellite/.rubies/ruby-${ruby_ver}"
     
-    ${ruby_installer} -i ${ruby_install_dir} -s ${ruby_src_dir} ruby 2.5.1
+    ${ruby_installer} -i ${ruby_install_dir} -s ${ruby_src_dir} ruby ${ruby_ver}
     chown -R bashellite:bashellite /home/bashellite/.rubies
     chmod -R 0700 /home/bashellite/.rubies
 
     # Check installation of ruby
-    if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby 2.5.1") == "ruby 2.5.1" ]]; then
+    if [[ -s "${ruby_bin}" && $(${ruby_bin} --version | grep -o "ruby ${ruby_ver}") == "ruby ${ruby_ver}" ]]; then
       echo "[INFO] ${bin_name} provider successfully installed.";
     else
       echo "[FAIL] ${bin_name} was NOT installed successfully; exiting." \

--- a/providers.d/gem/install_provider.sh
+++ b/providers.d/gem/install_provider.sh
@@ -23,7 +23,7 @@ main() {
   else
     echo "[WARN] ${bin_name} does NOT appear to be installed, (or it is broken); (re)installing..."
     # Download ruby-install
-    if [ ! -d ${providers_tld/gem/src/ruby-install} ]; then
+    if [ ! -d ${providers_tld}/gem/src/ruby-install ]; then
       git clone https://github.com/pcseanmckay/ruby-install ${providers_tld}/gem/src/ruby-install
     fi
     

--- a/providers.d/gem/provider_wrapper.sh
+++ b/providers.d/gem/provider_wrapper.sh
@@ -1,4 +1,5 @@
 bashelliteProviderWrapperGem() {
+  local ruby_ver="2.5.1"
   local mirror_file="${HOME}/.gem/.mirrorrc"
   utilMsg INFO "$(utilTime)" "Copying config contents to ${HOME}/.gem/.mirrorrc"
   if [[ ! -d "${HOME}/.gem" ]]; then
@@ -16,7 +17,7 @@ bashelliteProviderWrapperGem() {
   # Check for installed dependent gems required for mirroring
 
   utilMsg INFO "$(utilTime)" "Checking for required gems for mirroring..."
-  local gem_bin=${HOME}/.rubies/ruby-2.5.1/bin/gem
+  local gem_bin=${HOME}/.rubies/ruby-${ruby_ver}/bin/gem
   local gemlist=$(${gem_bin} list)
   for gem in \
       hoe \

--- a/providers.d/gem/provider_wrapper.sh
+++ b/providers.d/gem/provider_wrapper.sh
@@ -12,12 +12,33 @@ bashelliteProviderWrapperGem() {
   echo "  delete: false" >> ${mirror_file}
   echo "  skiperror: true" >> ${mirror_file}
   echo "..." >> ${mirror_file}
-  utilMsg INFO "$(utilTime)" "Downloading gems from gem server"
 
-  # use for loop to go through listing to find rubygems-mirror path
+  # Check for installed dependent gems required for mirroring
 
-  utilMsg INFO "$(utilTime)" "Downloading gems..."
-  cd ${_r_providers_tld}/gem/exec/gems/rubygems-mirror*
-  rake mirror:update
+  utilMsg INFO "$(utilTime)" "Checking for required gems for mirroring..."
+  local gem_bin=${HOME}/.rubies/ruby-2.5.1/bin/gem
+  local gemlist=$(${gem_bin} list)
+  for gem in \
+      hoe \
+      net-http-persistent \
+      rubygems-mirror \
+      ; do
+    if [[ "${gemlist}" != *"${gem}"* ]]; then 
+      utilMsg WARN "$(utilTime)" "${gem} gem dependency not found.  Installing..."
+      ${gem_bin} install ${gem}
+      gemlist=$(${gem_bin} list)
+      if [[ "${gemlist}" == *"${gem}"* ]]; then
+        utilMsg INFO "$(utilTime)" "Gem ${gem} installed successfully..."
+      else
+        utilMsg FAIL "$(utilTime)" "Required gem ${gem} was NOT installed successfully; exiting." \
+        && exit 1;
+      fi
+    else
+      utilMsg INFO "$(utilTime)" "Required gem ${gem} already installed..."
+    fi 
+  done
+
+  utilMsg INFO "$(utilTime)" "Downloading gems from gem server..."
+  ${gem_bin} mirror
 
 }


### PR DESCRIPTION
Corrected rubygems provider to now use a locally installed version of ruby (currently v2.5.1) installed to the bashellite home directory.