### PR TITLE
Added Dockerfile for easy RHEL 7 testing.

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -4,6 +4,7 @@ RUN yum update -y && \
                    https://rhel7.iuscommunity.org/ius-release.rpm && \
     yum update -y && \
     yum install -y bzip2 \
+                   createrepo \
                    git2u \
                    make \
                    python2-pip \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,9 +1,11 @@
-FROM registry.access.redhat.com/rhel7
-RUN yum update -y
-RUN yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y
-RUN yum install https://rhel7.iuscommunity.org/ius-release.rpm -y
-RUN yum update -y 
-RUN yum install git2u -y
-RUN yum install vim -y
-RUN yum install bzip2 -y
+FROM registry.access.redhat.com/rhel7:7.5
+RUN yum update -y && \
+    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y && \
+    yum install https://rhel7.iuscommunity.org/ius-release.rpm -y && \
+    yum update -y && \
+    yum install -y bzip2 \
+                   git2u \
+                   make \
+                   vim && \
+    yum clean all
 CMD /bin/bash

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,11 +1,17 @@
 FROM registry.access.redhat.com/rhel7:7.5
 RUN yum update -y && \
-    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y && \
-    yum install https://rhel7.iuscommunity.org/ius-release.rpm -y && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+                   https://rhel7.iuscommunity.org/ius-release.rpm && \
     yum update -y && \
     yum install -y bzip2 \
                    git2u \
                    make \
-                   vim && \
+                   python2-pip \
+                   python35u \
+                   python-virtualenv \
+                   reposync \
+                   rsync \
+                   vim \
+                   wget && \
     yum clean all
 CMD /bin/bash

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/rhel7
+RUN yum update -y
+RUN yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y
+RUN yum install https://rhel7.iuscommunity.org/ius-release.rpm -y
+RUN yum update -y 
+RUN yum install git2u -y
+RUN yum install vim -y
+RUN yum install bzip2 -y
+CMD /bin/bash


### PR DESCRIPTION
Dockerfile added to create basic RHEL 7 test docker image.  Current Dockerfile pulls RHEL 7 image, installed EPEL and IUS repositories, installs git2u, installs vim, and installs bzip2.