### PR TITLE
Feature/add pypi package list downloader dev script

### DIFF
--- a/dev/pypi_downloader.py
+++ b/dev/pypi_downloader.py
@@ -1,5 +1,5 @@
 from lxml import html, etree
-import requests, re, argparse, os, datetime, shutil
+import requests, re, argparse, os, datetime, shutil, logging
 
 
 # This function grabs a list of all the packages at the pypi index site specified by 'baseurl'
@@ -99,23 +99,26 @@ def processPackageFiles(pkg_name, base_url, base_save_loc):
 
                             if download_file:
                                 # Here we download the file
-                                print("[INFO]: Downloading " + file_name + "...")
+                                #print("[INFO]: Downloading " + file_name + "...")
+                                logging.info("Downloading " + file_name + "...")
                                 os.makedirs(file_dir, exist_ok=True)  # create (if not existing) path to file to be saved
                                 package_file_req = requests.get(file_url, stream=True)
                                 with open(file_loc, 'wb') as outfile:
                                     shutil.copyfileobj(package_file_req.raw, outfile)
                                 os.utime(file_loc, (file_url_time_epoch, file_url_time_epoch))
                             else:
-                                print("[INFO]: " + file_name + " exists, skipping...")
+                                logging.info(file_name + " exists, skipping...")
 
                         else:
-                            print("[WARN]: No package file url matched, skipping...")
+                            logging.warn("No package file url matched, skipping...")
                             continue
 
 
 ######################################### Start of main processing
 
 if __name__ == "__main__":
+    
+    logging.basicConfig(level=logging.INFO, format='[%(levelname)s]: %(message)s')
     args = parseCommandLine()
 
     mirror_tld = args.mirror_tld
@@ -124,12 +127,12 @@ if __name__ == "__main__":
     mirror_repo_loc = mirror_tld + "/" + repo_name
 
     if args.config_file is None:
-        print("[INFO]: No list of packages specified, downloading from pypi index: " + repo_url)
+        logging.info("No list of packages specified, downloading from pypi index: " + repo_url)
         pkgs = getPackageListFromIndex(repo_url)
     else:
         pkgs = args.config_file.read().split()
 
     for p in pkgs:
-        print("[INFO]: Processing package " + p + "...")
+        logging.info("Processing package " + p + "...")
         processPackageIndex(p, repo_url, mirror_repo_loc)
         processPackageFiles(p, repo_url, mirror_repo_loc)

--- a/dev/pypi_packages.py
+++ b/dev/pypi_packages.py
@@ -1,5 +1,5 @@
 from lxml import html, etree
-import requests, re, argparse, os, datetime, shutil, logging, sys
+import requests, re, argparse, logging
 
 
 # This function grabs a list of all the packages at the pypi index site specified by 'baseurl'

--- a/dev/pypi_packages.py
+++ b/dev/pypi_packages.py
@@ -1,0 +1,49 @@
+from lxml import html, etree
+import requests, re, argparse, os, datetime, shutil, logging, sys
+
+
+# This function grabs a list of all the packages at the pypi index site specified by 'baseurl'
+def getPackageListFromIndex(baseurl):
+    page = requests.get(baseurl + "/simple/")
+    tree = html.fromstring(page.content)
+    pkgs = tree.xpath("//@href")
+
+    newpkgs = []
+
+    for p in pkgs:
+        # Here we look for the simple package name for the package item
+        # returned in package list
+        pkg_name_match = re.search(r"simple/(.*)/", p, re.IGNORECASE)
+        if pkg_name_match:
+            tmp = pkg_name_match.group(1)
+            newpkgs.append(tmp)
+        else:
+            newpkgs.append(p)
+
+    return newpkgs
+
+
+# This function parses the command line arguments
+def parseCommandLine():
+    parser = argparse.ArgumentParser(
+        description="Script to download list of packages from a pypi index"
+        )
+    parser.add_argument('-u', dest='repo_url', default='https://pypi.org', help='URL of pypi index site')
+
+    args = parser.parse_args()
+
+    return args
+
+######################################### Start of main processing
+
+if __name__ == "__main__":
+    
+    logging.basicConfig(level=logging.INFO, format='[%(levelname)s]: %(message)s')
+    args = parseCommandLine()
+
+    repo_url = args.repo_url
+
+    pkgs = getPackageListFromIndex(repo_url)
+
+    for pkg_name in pkgs:
+        print(pkg_name)


### PR DESCRIPTION
This script adds the ability to query a pypi index (pypi.org is the default) for a full list of packages that is outputted to stdout.  This is a utility script that can be used with GNU parallel and the python pypi downloader dev script.